### PR TITLE
add WireMockInspector option

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,20 +5,21 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting" Version="8.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.2.0" />
     <!-- WireMock.Net -->
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.0" />
     <!-- OpenTelemetry -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <!-- Misc -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- WireMock -->
-    <PackageVersion Include="WireMock.Net.RestClient" Version="1.5.55" />
+    <PackageVersion Include="WireMock.Net.RestClient" Version="1.6.3" />
+    <PackageVersion Include="WireMock.Net.Extensions.WireMockInspector" Version="1.0.26" />
   </ItemGroup>
 </Project>

--- a/src/Aspire.Hosting.WireMock/Aspire.Hosting.WireMock.csproj
+++ b/src/Aspire.Hosting.WireMock/Aspire.Hosting.WireMock.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="WireMock.Net.Extensions.WireMockInspector" />
     <PackageReference Include="WireMock.Net.RestClient" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.WireMock/WireMockNetConfigHook.cs
+++ b/src/Aspire.Hosting.WireMock/WireMockNetConfigHook.cs
@@ -3,6 +3,7 @@ using Aspire.Hosting.Lifecycle;
 using RestEase;
 using WireMock.Client;
 using WireMock.Client.Extensions;
+using WireMock.Net.Extensions.WireMockInspector;
 
 namespace Aspire.Hosting.WireMock;
 internal class WireMockNetConfigHook : IDistributedApplicationLifecycleHook
@@ -24,6 +25,11 @@ internal class WireMockNetConfigHook : IDistributedApplicationLifecycleHook
                     RestClient.For<IWireMockAdminApi>(new Uri(wireMockInstance.PrimaryEndpoint.Url, UriKind.Absolute));
                 var mappingBuilder = _wireMockAdminApi.GetMappingBuilder();
                 wireMockInstance.ApiMappingBuilder?.Invoke(mappingBuilder);
+
+                if(wireMockInstance.EnabledWireMockInspector)
+                {
+                    WireMockServerExtensions.Inspect(wireMockInstance.PrimaryEndpoint.Url);
+                }
             }
         }
 

--- a/src/Aspire.Hosting.WireMock/WireMockNetExtensions.cs
+++ b/src/Aspire.Hosting.WireMock/WireMockNetExtensions.cs
@@ -16,10 +16,11 @@ public static class WireMockNetExtensions
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="port">External port</param>
+    /// <param name="enableWireMockInspector">Enable WireMock Inspector</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{WireMockNetResource}"/>.</returns>
-    public static IResourceBuilder<WireMockNetResource> AddWireMockNet(this IDistributedApplicationBuilder builder, string name, int? port = null)
+    public static IResourceBuilder<WireMockNetResource> AddWireMockNet(this IDistributedApplicationBuilder builder, string name, int? port = null, bool enableWireMockInspector = false)
     {
-        var wireMockResource = new WireMockNetResource(name);
+        var wireMockResource = new WireMockNetResource(name,enableWireMockInspector);
 
         return builder
             .AddResource(wireMockResource)

--- a/src/Aspire.Hosting.WireMock/WireMockNetResource.cs
+++ b/src/Aspire.Hosting.WireMock/WireMockNetResource.cs
@@ -7,7 +7,8 @@ namespace Aspire.Hosting;
 /// A resource that represents a WireMock.Net resource.
 /// </summary>
 /// <param name="name">The resource name.</param>
-public class WireMockNetResource(string name) : ContainerResource(name), IResourceWithServiceDiscovery
+/// <param name="enableWireMockInspector">Enable WireMock Inspector</param>
+public class WireMockNetResource(string name, bool enableWireMockInspector) : ContainerResource(name), IResourceWithServiceDiscovery
 {
     internal const string PrimaryEndpointName = "http";
 
@@ -19,4 +20,7 @@ public class WireMockNetResource(string name) : ContainerResource(name), IResour
     /// Gets the primary endpoint for the server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+    
+    
+     public bool EnabledWireMockInspector => enableWireMockInspector;
 }


### PR DESCRIPTION
Hi,

I have added a param for configure [WireMockInspector](https://github.com/WireMock-Net/WireMockInspector)

``` c#
if(wireMockInstance.EnabledWireMockInspector)
  {
      WireMockServerExtensions.Inspect(wireMockInstance.PrimaryEndpoint.Url);
  }

```
Thanks for the project, very helpfull
Regards
Andoni